### PR TITLE
GmsAccount: If there's no network and FRP isn't enforcing, skip GMS

### DIFF
--- a/src/com/cyanogenmod/setupwizard/setup/GmsAccountPage.java
+++ b/src/com/cyanogenmod/setupwizard/setup/GmsAccountPage.java
@@ -102,7 +102,12 @@ public class GmsAccountPage extends SetupPage {
             getCallbacks().onPreviousPage();
         } else {
             super.doLoadAction(fragmentManager, action);
-            if (!SetupWizardUtils.accountExists(mContext, SetupWizardApp.ACCOUNT_TYPE_GMS)) {
+            if (!SetupWizardUtils.isNetworkConnected(mContext) && !SetupWizardUtils.frpEnabled(mContext)) {
+                if (SetupWizardApp.DEBUG) {
+                    Log.d(TAG, "No network, no FRP enforcement, skip GMS account");
+                }
+                getCallbacks().onNextPage();
+            } else if (!SetupWizardUtils.accountExists(mContext, SetupWizardApp.ACCOUNT_TYPE_GMS)) {
                 launchGmsAccountSetup();
             } else {
                 // This can happen if the user goes from setup -> restore, but chooses to set


### PR DESCRIPTION
The current version of GMS's SuW has the main activity return as
CANCELED when no network is available. This is the same result as
an actual cancellation (by pressing "Back"), and there's no extra
data to distinguish the two, so the user gets stuck in a loop between
the "no network" page and the one preceding it, unless connectivity
is somehow established. Making connectivity mandatory for OOBE isn't
acceptable, so skip GMS entirely if network is absent (and FRP
isn't enforcing). The only thing it was presenting was a "you
have no network" dialog anyway.

Change-Id: I2abadc79a0823e94da7d3a875ce6db8eae8f143b
(cherry picked from commit d82b2dc88a8a7ef5224ca20529e4288f7d2fc913)