### PR TITLE
SetupWizard: Set min date to build date

### DIFF
--- a/src/com/cyanogenmod/setupwizard/DateTimeActivity.java
+++ b/src/com/cyanogenmod/setupwizard/DateTimeActivity.java
@@ -40,6 +40,8 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.TimePicker;
 
+import com.cyanogenmod.setupwizard.util.SetupWizardUtils;
+
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.util.ArrayList;
@@ -140,8 +142,16 @@ public class DateTimeActivity extends BaseSetupWizardActivity implements
                 final Calendar calendar = Calendar.getInstance();
                 final boolean isEpoch = calendar.get(Calendar.YEAR) == 1970;
                 if (isEpoch) {
-                    // If epoch, set date to a default date
-                    setDate(DateTimeActivity.this, 2016, Calendar.JANUARY, 1);
+                    // If epoch, set date to build date
+                    long timestamp = SetupWizardUtils.getBuildDateTimestamp();
+                    if (timestamp > 0) {
+                        calendar.setTimeInMillis(timestamp * 1000);
+                        setDate(DateTimeActivity.this, calendar.get(Calendar.YEAR),
+                                calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH));
+                    } else {
+                        // no build date available, use a sane default
+                        setDate(DateTimeActivity.this, 2017, Calendar.JANUARY, 1);
+                    }
                 }
             }
         });

--- a/src/com/cyanogenmod/setupwizard/util/SetupWizardUtils.java
+++ b/src/com/cyanogenmod/setupwizard/util/SetupWizardUtils.java
@@ -44,6 +44,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ServiceInfo;
 import android.hardware.fingerprint.FingerprintManager;
 import android.os.Binder;
+import android.os.SystemProperties;
 import android.os.UserHandle;
 import android.provider.Settings;
 import android.telephony.ServiceState;
@@ -75,6 +76,8 @@ public class SetupWizardUtils {
     private static final String GMS_PACKAGE = "com.google.android.gms";
     private static final String GMS_SUW_PACKAGE = "com.google.android.setupwizard";
     private static final String GMS_TV_SUW_PACKAGE = "com.google.android.tungsten.setupwraith";
+
+    private static final String PROP_BUILD_DATE = "ro.build.date.utc";
 
     private SetupWizardUtils(){}
 
@@ -358,4 +361,8 @@ public class SetupWizardUtils {
     public static final ComponentName mTvAddAccessorySettingsActivity =
             new ComponentName("com.android.tv.settings",
                     "com.android.tv.settings.accessories.AddAccessoryActivity");
+
+    public static long getBuildDateTimestamp() {
+        return SystemProperties.getLong(PROP_BUILD_DATE, 0);
+    }
 }


### PR DESCRIPTION
* Use "ro.build.date.utc" as a base
* Fallback to beginning of 2017 if the date can't be determined for
  whatever reason

Change-Id: I48cd9eb1928f5e3e3240a75508549712f5e53413